### PR TITLE
fix build due missing headers

### DIFF
--- a/common/plane/plane.h
+++ b/common/plane/plane.h
@@ -2,6 +2,7 @@
 #define __Common_Plane_H__
 
 #include "../utils/utils.h"
+#include <cstddef>
 
 namespace Filtering {
 


### PR DESCRIPTION
if not, fail build

~~~make
[  1%] Building CXX object common/CMakeFiles/common.dir/constraints/constraints.cpp.o
In file included from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:5,
                 from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:1:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:14:4: error: 'ptrdiff_t' does not name a type
   14 |    ptrdiff_t nPitch;
      |    ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:5:1: note: 'ptrdiff_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
    4 | #include "../utils/utils.h"
  +++ |+#include <cstddef>
    5 | 
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:23:21: error: 'ptrdiff_t' has not been declared
   23 |    Plane(T *pPixel, ptrdiff_t nPitch, int nWidth, int nHeight, int nPixelSize, int nOrigHeight) : pPixel(pPixel), nPitch(nPitch), nWidth(nWidth), nHeight(nHeight), nPixelSize(nPixelSize), nOrigHeight(nOrigHeight) { }
      |                     ^~~~~~~~~
In file included from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:5,
                 from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:1:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:30:4: error: 'ptrdiff_t' does not name a type
   30 |    ptrdiff_t pitch() const { return nPitch; }
      |    ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:30:4: note: 'ptrdiff_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
In file included from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:5,
                 from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:1:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h: In constructor 'Filtering::Plane<T>::Plane()':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:22:28: error: class 'Filtering::Plane<T>' does not have any field named 'nPitch'
   22 |    Plane() : pPixel(NULL), nPitch(0), nWidth(0), nHeight(0), nPixelSize(1), nOrigHeight(0) {}
      |                            ^~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h: In constructor 'Filtering::Plane<T>::Plane(T*, int, int, int, int, int)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:23:115: error: class 'Filtering::Plane<T>' does not have any field named 'nPitch'
   23 |    Plane(T *pPixel, ptrdiff_t nPitch, int nWidth, int nHeight, int nPixelSize, int nOrigHeight) : pPixel(pPixel), nPitch(nPitch), nWidth(nWidth), nHeight(nHeight), nPixelSize(nPixelSize), nOrigHeight(nOrigHeight) { }
      |                                                                                                                   ^~~~~~
In file included from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:5,
                 from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:1:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h: In constructor 'Filtering::Plane<T>::Plane(const Filtering::Plane<const T>&)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:25:63: error: class 'Filtering::Plane<T>' does not have any field named 'nPitch'
   25 |    Plane(const Plane<const T> &plane) : pPixel(plane.data()), nPitch(plane.pitch()), nWidth(plane.width()), nHeight(plane.height()), nPixelSize(plane.pixelsize()), nOrigHeight(plane.origheight())
      |                                                               ^~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h: In member function 'Filtering::Plane<T> Filtering::Plane<T>::offset(int, int, int, int) const':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:38:53: error: 'nPitch' was not declared in this scope
   38 |      return Plane<T>( pPixel + x * nPixelSize + y * nPitch, nPitch, w, h, nPixelSize, nOrigHeight ); // byte pointers->x*pixelsize
      |                                                     ^~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h: In member function 'void Filtering::Plane<T>::print() const':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/../plane/plane.h:45:86: error: 'nPitch' was not declared in this scope
   45 |      Filtering::print(LOG_DEBUG, "plane 0x%x (%ix%i:%i)\n", pPixel, nWidth, nHeight, nPitch);
      |                                                                                      ^~~~~~
In file included from /tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:1:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h: At global scope:
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:65:78: error: 'ptrdiff_t' has not been declared
   65 |    Constraint(CpuFlags flags, int nWidth, int nHeight, const Byte *pAddress, ptrdiff_t nPitch);
      |                                                                              ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.h:66:72: error: 'ptrdiff_t' has not been declared
   66 |    Constraint(CpuFlags flags, int nWidth, int nHeight, Int64 nAddress, ptrdiff_t nPitch);
      |                                                                        ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:46:87: error: 'ptrdiff_t' has not been declared
   46 | Constraint::Constraint(CpuFlags flags, int nWidth, int nHeight, const Byte *pAddress, ptrdiff_t nPitch) :
      |                                                                                       ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:49:81: error: 'ptrdiff_t' has not been declared
   49 | Constraint::Constraint(CpuFlags flags, int nWidth, int nHeight, Int64 nAddress, ptrdiff_t nPitch) :
      |                                                                                 ^~~~~~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp: In constructor 'Filtering::Constraint::Constraint(Filtering::CpuFlags, const Filtering::Plane<const unsigned char>&)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:53:160: error: 'const class Filtering::Plane<const unsigned char>' has no member named 'pitch'
   53 | flags(flags), moduloX(toModulo(plane.width())), moduloY(toModulo(plane.height())), alignment(toAlignment(Int64(static_cast<const Byte*>(plane.data())) | plane.pitch())), nMinimumWidth(plane.width()) {}
      |                                                                                                                                                                ^~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp: In constructor 'Filtering::Constraint::Constraint(Filtering::CpuFlags, const Filtering::Plane<unsigned char>&)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:56:160: error: 'const class Filtering::Plane<unsigned char>' has no member named 'pitch'
   56 | flags(flags), moduloX(toModulo(plane.width())), moduloY(toModulo(plane.height())), alignment(toAlignment(Int64(static_cast<const Byte*>(plane.data())) | plane.pitch())), nMinimumWidth(plane.width()) {}
      |                                                                                                                                                                ^~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp: In constructor 'Filtering::Constraint::Constraint(const Filtering::Constraint&, const Filtering::Plane<unsigned char>&)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:59:236: error: 'const class Filtering::Plane<unsigned char>' has no member named 'pitch'
   59 | flags(constraint.flags), moduloX(constraint.moduloX & toModulo(plane.width())), moduloY(constraint.moduloY & toModulo(plane.height())), alignment(constraint.alignment & toAlignment(Int64(static_cast<const Byte*>(plane.data())) | plane.pitch())), nMinimumWidth(plane.width()) {}
      |                                                                                                                                                                                                                                            ^~~~~
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp: In constructor 'Filtering::Constraint::Constraint(const Filtering::Constraint&, const Filtering::Plane<const unsigned char>&)':
/tmp/makepkg/avisynth-plugin-masktools2-git/src/masktools2/common/constraints/constraints.cpp:62:236: error: 'const class Filtering::Plane<const unsigned char>' has no member named 'pitch'
   62 | flags(constraint.flags), moduloX(constraint.moduloX & toModulo(plane.width())), moduloY(constraint.moduloY & toModulo(plane.height())), alignment(constraint.alignment & toAlignment(Int64(static_cast<const Byte*>(plane.data())) | plane.pitch())), nMinimumWidth(plane.width()) {}
      |                                                                                                                                                                                                                                            ^~~~~
make[2]: *** [common/CMakeFiles/common.dir/build.make:76: common/CMakeFiles/common.dir/constraints/constraints.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:143: common/CMakeFiles/common.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
~~~